### PR TITLE
Use HOME env var for db file

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 ################### DataSource Configuration ##########################
 
 jdbc.driverClassName=org.h2.Driver
-jdbc.url=jdbc:h2:~/test
+jdbc.url=jdbc:h2:${HOME}/test
 jdbc.username=sa
 jdbc.password=
 


### PR DESCRIPTION
For some reasons `~` does not work correctly in Vertx Devfile
![Screenshot_20190627_153205](https://user-images.githubusercontent.com/5887312/60266749-5dd08e00-98f1-11e9-8afc-1a008c9353be.png)

This PR replaces it with ${HOME}

It's needed to https://github.com/eclipse/che-devfile-registry/pull/18